### PR TITLE
fix require problem

### DIFF
--- a/var/www/openmediavault/js/omv/module/admin/diagnostic/log/plugin/LetsEncrypt.js
+++ b/var/www/openmediavault/js/omv/module/admin/diagnostic/log/plugin/LetsEncrypt.js
@@ -19,6 +19,8 @@
  * along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
  */
 
+// require("js/omv/module/admin/diagnostic/log/plugin/Plugin.js")
+
 Ext.define("OMV.module.admin.diagnostic.log.plugin.LetsEncrypt", {
     extend: "OMV.module.admin.diagnostic.log.plugin.Plugin",
     alias: "omv.plugin.diagnostic.log.letsencrypt",

--- a/var/www/openmediavault/js/omv/module/admin/service/letsencrypt/Settings.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/letsencrypt/Settings.js
@@ -17,6 +17,8 @@
 
 // require("js/omv/WorkspaceManager.js")
 // require("js/omv/workspace/form/Panel.js")
+// require("js/omv/window/Execute.js")
+// require("js/omv/Rpc.js")
 
 Ext.define("OMV.module.admin.service.letsencrypt.Settings", {
     extend: "OMV.workspace.form.Panel",


### PR DESCRIPTION
since omv-letsencrypt dosen't require properly, when multiple plugin installed,
require order problem can be occured

for example, if when you install both
omv-letsencrypt
omv-sabnzbd 
you cannot enter admin page due to incorrect require order

problem is described more detail [here](http://forums.openmediavault.org/index.php/Thread/12452-openmediavault-letsencrypt/?postID=119840#post119840) 
